### PR TITLE
Fix fastq and bam find when creating config file

### DIFF
--- a/illumina_createConfig.pl
+++ b/illumina_createConfig.pl
@@ -89,7 +89,10 @@ sub createConfig {
 	foreach my $fastqDir (@fastqDirs){
 	    if(! -e $fastqDir) { die "$fastqDir does not exist." }
 	    print CONFIG "# $fastqDir\n";
-	    my @fastqFiles = glob($fastqDir."/*{/,}*{/,}*.fastq.gz");
+	    my $query_one = $fastqDir."/*.fastq.gz "; # look in fastq folder
+	    my $query_two = $fastqDir."/*/*.fastq.gz "; # look one folder deep
+	    my $query_three = $fastqDir."/*/*/*.fastq.gz "; # look two folders deep
+	    my @fastqFiles = glob($query_one.$query_two.$query_three);
 	    foreach my $fastqFile (@fastqFiles){ print CONFIG "FASTQ\t$fastqFile\n" }
 	}
     }
@@ -99,7 +102,9 @@ sub createConfig {
 	foreach my $bamDir (@bamDirs){
 	    if(! -e $bamDir) { die "$bamDir does not exist." }
 	    print CONFIG "# $bamDir\n";
-	    my @bamFiles = glob($bamDir."/*{/,}*.bam");
+	    my $query_one = $bamDir."/*.bam "; # look in bam folder
+	    my $query_two = $bamDir."/*/*.bam "; # look one folder deep
+	    my @bamFiles = glob($query_one.$query_two);
 	    foreach my $bamFile (@bamFiles){
 		my $baiFile = $bamFile;
 		$baiFile =~ s/\.bam/.bai/;


### PR DESCRIPTION
This should fix the duplication of fastq files in the config file. 

# Three levels
```
OLD:
$VAR1 = [
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_1/test_1.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_2/test_2.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_2/project_1/test_4.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_2/project_2/test_3.fastq'
        ];
NEW :
$VAR1 = [
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_1/test_1.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_2/test_2.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_2/project_1/test_4.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_2/project_2/test_3.fastq'
        ];
```
# Two levels
```
OLD:
$VAR1 = [
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_1/test_1.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_2/test_2.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_1/test_1.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_2/test_2.fastq'
        ];
New:
$VAR1 = [
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_1/test_1.fastq',
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_2/test_2.fastq'
        ];
```
# One level
```
OLD:
$VAR1 = [
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_1//test_1.fastq'
        ];
NEW:
$VAR1 = [
          '/hpc/cog_bioinf/data/robert/fastq_check/sequencer_1/run_1/project_1//test_1.fastq'
        ];

```