### PR TITLE
Feature hartwig v1.9 changes

### DIFF
--- a/illumina_pipeline.pl
+++ b/illumina_pipeline.pl
@@ -594,7 +594,7 @@ sub checkConfig{
 	    if(! $opt{FREEBAYES_TIME}){ print "ERROR: No FREEBAYES_TIME option found in config files.\n"; $checkFailed = 1; }
 	    if(! $opt{FREEBAYES_SETTINGS}){ print "ERROR: No FREEBAYES_SETTINGS option found in config files.\n"; $checkFailed = 1; }
 	    if(! $opt{FREEBAYES_SOMATICFILTER}){ print "ERROR: No FREEBAYES_SOMATICFILTER option found in config files.\n"; $checkFailed = 1; }
-	    if(! $opt{FREEBAYES_GERMLINEFILTER}){ print "ERROR: No FREEBAYES_GERMLINEFILTER option found in config files.\n"; $checkFailed = 1; }
+	    #if(! $opt{FREEBAYES_GERMLINEFILTER}){ print "ERROR: No FREEBAYES_GERMLINEFILTER option found in config files.\n"; $checkFailed = 1; }
 	}
 	if(! $opt{SOMVAR_MUTECT}){ print "ERROR: No SOMVAR_MUTECT option found in config files.\n"; $checkFailed = 1; }
 	if($opt{SOMVAR_MUTECT} eq "yes"){

--- a/illumina_somaticVariants.pm
+++ b/illumina_somaticVariants.pm
@@ -218,7 +218,7 @@ sub runStrelka {
     print STRELKA_SH "\t$opt{STRELKA_PATH}/bin/configureStrelkaWorkflow.pl --tumor $sample_tumor_bam --normal $sample_ref_bam --ref $opt{GENOME} --config $opt{STRELKA_INI} --output-dir $strelka_out_dir\n\n";
 
     print STRELKA_SH "\tcd $strelka_out_dir\n";
-    print STRELKA_SH "\tmake -j 8\n\n";
+    print STRELKA_SH "\tmake -j $opt{STRELKA_THREADS}\n\n";
 
     # Check strelka completed
     print STRELKA_SH "\tif [ -f $strelka_out_dir/task.complete ]\n";

--- a/illumina_somaticVariants.pm
+++ b/illumina_somaticVariants.pm
@@ -215,6 +215,9 @@ sub runStrelka {
     print STRELKA_SH "\techo \"Start Strelka\t\" `date` \"\t $sample_ref_bam \t $sample_tumor_bam\t\" `uname -n` >> $log_dir/strelka.log\n\n";
 
     # Run Strelka
+    if (-e $strelka_out_dir){
+	print STRELKA_SH "\trm -r $strelka_out_dir \n";
+    }
     print STRELKA_SH "\t$opt{STRELKA_PATH}/bin/configureStrelkaWorkflow.pl --tumor $sample_tumor_bam --normal $sample_ref_bam --ref $opt{GENOME} --config $opt{STRELKA_INI} --output-dir $strelka_out_dir\n\n";
 
     print STRELKA_SH "\tcd $strelka_out_dir\n";

--- a/scripts/filterFreebayes.py
+++ b/scripts/filterFreebayes.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+"""
+filterFreebayes.py
+Applies BCBIO developed filters to the freebayes somatic output.
+2 main filters applied:
+1. LOD Tumor, LOD Normal > 3.5
+2. Freq of Tumor / Freq Normal > 2.7
+"""
+
+import argparse
+import re
+
+TUMOR_PARTS_INDEX = 10
+NORMAL_PARTS_INDEX = 9
+
+# Thresholds are like phred scores, so 3.5 = phred35
+TUMOR_THRESHOLD = 3.5
+NORMAL_THRESHOLD = 3.5
+
+# Code copied from BCBIO Freebayes pipeline.
+def customFilterFreebayes(vcf_file):
+    with open(vcf_file, "r") as f:
+        stripped_lines = (line.strip("\n") for line in f)
+        somatic_lines = (line for line in stripped_lines if _check_line(line))
+        print "\n".join(somatic_lines)
+
+### Filtering
+
+def _check_line(line):
+    parts = line.split("\t")
+    return line.startswith("#") or (_check_lods(parts, TUMOR_THRESHOLD, NORMAL_THRESHOLD) and _check_freqs(parts))
+
+def _check_lods(parts, tumor_thresh, normal_thresh):
+    """Ensure likelihoods for tumor and normal pass thresholds.
+
+    Skipped if no FreeBayes GL annotations available.
+    """
+    try:
+        gl_index = parts[8].split(":").index("GL")
+    except ValueError:
+        return True
+    try:
+        tumor_gls = [float(x) for x in parts[TUMOR_PARTS_INDEX].split(":")[gl_index].split(",") if x != "."]
+        if tumor_gls:
+            tumor_lod = max(tumor_gls[i] - tumor_gls[0] for i in range(1, len(tumor_gls)))
+        else:
+            tumor_lod = -1.0
+    # No GL information, no tumor call (so fail it)
+    except IndexError:
+        tumor_lod = -1.0
+    try:
+        normal_gls = [float(x) for x in parts[NORMAL_PARTS_INDEX].split(":")[gl_index].split(",") if x != "."]
+        if normal_gls:
+            normal_lod = min(normal_gls[0] - normal_gls[i] for i in range(1, len(normal_gls)))
+        else:
+            normal_lod = normal_thresh
+    # No GL inofmration, no normal call (so pass it)
+    except IndexError:
+        normal_lod = normal_thresh
+    return normal_lod >= normal_thresh and tumor_lod >= tumor_thresh
+
+def _check_freqs(parts):
+    """Ensure frequency of tumor to normal passes a reasonable threshold.
+
+    Avoids calling low frequency tumors also present at low frequency in normals,
+    which indicates a contamination or persistent error.
+    """
+    thresh_ratio = 2.7
+    try:  # FreeBayes
+        ao_index = parts[8].split(":").index("AO")
+        ro_index = parts[8].split(":").index("RO")
+    except ValueError:
+        ao_index, ro_index = None, None
+    try:  # VarDict
+        af_index = parts[8].split(":").index("AF")
+    except ValueError:
+        af_index = None
+    if af_index is None and ao_index is None:
+        raise NotImplementedError("Unexpected format annotations: %s" % parts[0])
+    def _calc_freq(item):
+        try:
+            if ao_index is not None and ro_index is not None:
+                ao = sum([int(x) for x in item.split(":")[ao_index].split(",")])
+                ro = int(item.split(":")[ro_index])
+                freq = ao / float(ao + ro)
+            elif af_index is not None:
+                freq = float(item.split(":")[af_index])
+        except (IndexError, ValueError, ZeroDivisionError):
+            freq = 0.0
+        return freq
+    tumor_freq, normal_freq = _calc_freq(parts[TUMOR_PARTS_INDEX]), _calc_freq(parts[NORMAL_PARTS_INDEX])
+    return normal_freq <= 0.001 or normal_freq <= tumor_freq / thresh_ratio
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(formatter_class=lambda prog: argparse.HelpFormatter(prog,max_help_position=100, width=200))
+
+    required_named = parser.add_argument_group("required named arguments")
+    required_named.add_argument("-v", "--vcf_file", help="path/to/file.vcf", required=True)
+
+    args = parser.parse_args()
+    customFilterFreebayes(args.vcf_file)

--- a/settings/CPCT.ini
+++ b/settings/CPCT.ini
@@ -186,7 +186,7 @@ PILEUP_MEM	60
 SOMVAR_FREEBAYES	yes
 FREEBAYES_QUEUE	all.q
 FREEBAYES_TIME	24:0:0
-FREEBAYES_THREADS	4
+FREEBAYES_THREADS	2
 FREEBAYES_MEM	40
 FREEBAYES_SETTINGS	--min-alternate-fraction 0.1 -C 2 --no-partial-observation --pooled-continuous --report-genotype-likelihood-max --allele-balance-priors-off --pooled-discrete --genotype-qualities --min-coverage 5 --no-mnps --no-complex
 FREEBAYES_SOMATICFILTER	(QUAL>=1)

--- a/settings/CPCT.ini
+++ b/settings/CPCT.ini
@@ -28,7 +28,7 @@ VCFTOOLS_PATH	/hpc/local/CentOS7/cog_bioinf/vcftools-0.1.14/bin
 # Somatic
 STRELKA_PATH	/hpc/local/CentOS7/cog_bioinf/strelka_workflow-1.0.14
 VARSCAN_PATH	/hpc/local/CentOS7/cog_bioinf/varscan-2.4.1/VarScan.v2.4.1.jar
-FREEBAYES_PATH	/hpc/local/CentOS7/cog_bioinf/freebayes_v0.9.14/bin
+FREEBAYES_PATH	/hpc/local/CentOS7/cog_bioinf/freebayes_v1.0.2/bin
 MUTECT_PATH	/hpc/local/CentOS7/cog_bioinf/mutect-1.1.7
 
 # Copy Number
@@ -175,8 +175,8 @@ VARSCAN_QUEUE	all.q
 VARSCAN_TIME	8:0:0
 VARSCAN_THREADS	2
 VARSCAN_MEM	20
-VARSCAN_SETTINGS	--min-coverage 20 --min-var-freq 0.1 --tumor-purity 0.8
-VARSCAN_POSTSETTINGS	-max-normal-freq 0.02 --p-value 0.05
+VARSCAN_SETTINGS	--min-var-freq 0.1
+VARSCAN_POSTSETTINGS	--p-value 0.05
 PILEUP_QUEUE	all.q
 PILEUP_TIME	24:0:0
 PILEUP_THREADS	12
@@ -188,9 +188,8 @@ FREEBAYES_QUEUE	all.q
 FREEBAYES_TIME	24:0:0
 FREEBAYES_THREADS	4
 FREEBAYES_MEM	40
-FREEBAYES_SETTINGS	-C 3 --pooled-discrete --genotype-qualities --min-coverage 5 --no-mnps --no-complex
-FREEBAYES_SOMATICFILTER	(GEN[ALL].DP>=20) & (GEN[ALL].GQ>=15) & (QUAL>=10) & (FB_SSC>=20)
-FREEBAYES_GERMLINEFILTER	(GEN[ALL].DP>=20) & (GEN[ALL].GQ>=15) & (QUAL>=10)
+FREEBAYES_SETTINGS	--min-alternate-fraction 0.1 -C 2 --no-partial-observation --pooled-continuous --report-genotype-likelihood-max --allele-balance-priors-off --pooled-discrete --genotype-qualities --min-coverage 5 --no-mnps --no-complex
+FREEBAYES_SOMATICFILTER	(QUAL>=1)
 
 ## Mutect
 SOMVAR_MUTECT	yes

--- a/settings/UMCU_Genome_somatic.ini
+++ b/settings/UMCU_Genome_somatic.ini
@@ -28,7 +28,7 @@ VCFTOOLS_PATH	/hpc/local/CentOS7/cog_bioinf/vcftools-0.1.14/bin
 # Somatic
 STRELKA_PATH	/hpc/local/CentOS7/cog_bioinf/strelka_workflow-1.0.14
 VARSCAN_PATH	/hpc/local/CentOS7/cog_bioinf/varscan-2.4.1/VarScan.v2.4.1.jar
-FREEBAYES_PATH	/hpc/local/CentOS7/cog_bioinf/freebayes_v0.9.14/bin
+FREEBAYES_PATH	/hpc/local/CentOS7/cog_bioinf/freebayes_v1.0.2/bin
 MUTECT_PATH	/hpc/local/CentOS7/cog_bioinf/mutect-1.1.7
 
 # Copy Number
@@ -177,8 +177,8 @@ VARSCAN_QUEUE	all.q
 VARSCAN_TIME	8:0:0
 VARSCAN_THREADS	2
 VARSCAN_MEM	20
-VARSCAN_SETTINGS	--min-coverage 20 --min-var-freq 0.1 --tumor-purity 0.8
-VARSCAN_POSTSETTINGS	-max-normal-freq 0.02 --p-value 0.05
+VARSCAN_SETTINGS	--min-var-freq 0.1
+VARSCAN_POSTSETTINGS	--p-value 0.05
 PILEUP_QUEUE	all.q
 PILEUP_TIME	24:0:0
 PILEUP_THREADS	7
@@ -190,9 +190,8 @@ FREEBAYES_QUEUE	all.q
 FREEBAYES_TIME	24:0:0
 FREEBAYES_THREADS	4
 FREEBAYES_MEM	40
-FREEBAYES_SETTINGS	-C 3 --pooled-discrete --genotype-qualities --min-coverage 5 --no-mnps --no-complex
-FREEBAYES_SOMATICFILTER	(GEN[ALL].DP>=20) & (GEN[ALL].GQ>=15) & (QUAL>=10) & (FB_SSC>=20)
-FREEBAYES_GERMLINEFILTER	(GEN[ALL].DP>=20) & (GEN[ALL].GQ>=15) & (QUAL>=10)
+FREEBAYES_SETTINGS	--min-alternate-fraction 0.1 -C 2 --no-partial-observation --pooled-continuous --report-genotype-likelihood-max --allele-balance-priors-off --pooled-discrete --genotype-qualities --min-coverage 5 --no-mnps --no-complex
+FREEBAYES_SOMATICFILTER	(QUAL>=1)
 
 ## Mutect
 SOMVAR_MUTECT	yes

--- a/settings/UMCU_Genome_somatic.ini
+++ b/settings/UMCU_Genome_somatic.ini
@@ -181,14 +181,14 @@ VARSCAN_SETTINGS	--min-var-freq 0.1
 VARSCAN_POSTSETTINGS	--p-value 0.05
 PILEUP_QUEUE	all.q
 PILEUP_TIME	24:0:0
-PILEUP_THREADS	7
+PILEUP_THREADS	12
 PILEUP_MEM	60
 
 ## Freebayes
 SOMVAR_FREEBAYES	yes
 FREEBAYES_QUEUE	all.q
 FREEBAYES_TIME	24:0:0
-FREEBAYES_THREADS	4
+FREEBAYES_THREADS	2
 FREEBAYES_MEM	40
 FREEBAYES_SETTINGS	--min-alternate-fraction 0.1 -C 2 --no-partial-observation --pooled-continuous --report-genotype-likelihood-max --allele-balance-priors-off --pooled-discrete --genotype-qualities --min-coverage 5 --no-mnps --no-complex
 FREEBAYES_SOMATICFILTER	(QUAL>=1)

--- a/settings/strelka/strelka_config_bwa_genome.ini
+++ b/settings/strelka/strelka_config_bwa_genome.ini
@@ -114,7 +114,7 @@ ssnvQuality_LowerBound = 15
 ; Somatic quality score (QSI_NT, NT=ref) below which somatic indels
 ; are marked as filtered:
 ;
-sindelQuality_LowerBound = 30
+sindelQuality_LowerBound = 20
 
 ;
 ; Optionally write out read alignments which were altered during the


### PR DESCRIPTION
Apply changes from Hartwig IAP version 1.9 (https://github.com/hartwigmedical/pipeline/releases/tag/v1.9) to this repo.

## Hartwig IAP changelog:

**Somatic calling changes**

- ~~Mutect~~
 - ~~Remove use of cosmic~~ -> Change ignored in this repo might lead to false negatives. Effect of this can not be estimated using the artificial (non-tumor) giab test set. 
- Strelka :white_check_mark:
 - indelQualityLowerBound from 30 to 20
- Freebayes :white_check_mark:
 - Switch from 0.9.14 to 1.0.2 to get rid of GQ=0 bug
 - Replace filtering commands with BCBIO version (scripts/filterFreebayes.py) + additional filter for QUAL>=1
 - Various changes to settings (see CPCT.ini, FREEBAYES_SETTINGS)
- Varscan :white_check_mark:
 - Remove min-coverage 20
 - Remove tumor purity 0.8
 - Remove max-normal-freq 0.02 in post settings

**Improved infrastructure & tooling**

- Fixed bug in memory usage in sambamba merge -> Update to upcoming sambamba version?
 - ~~No more excl tag used in grid engine as we do not expect a specific node is required to run sambamba merge~~
- New version and build chain for sambamba: -> Update to upcoming sambamba version?
 - ~~Easier to debug potential bugs.~~
 - Improved performance of pileup, together with chained usage of parallel bgzip
 - ~~Do note that as of release, the binaries provided by sambamba are unreliable.~~
- Strelka actually uses the threads it is configured to use. :white_check_mark:
- Tune other somatic callers to use 1 thread, which is what they use in practice anyways. :white_check_mark:
- ~~Removed changing open file limit from within merge script~~
 - ~~Added the option to retain the individual sample pileups after a run~~
- ~~Replaced SOMATIC_REGEX with explicit sample/tumor names configured in meta data.~~

**Bug fixes**
- ~~Kinship.done check did not work, we would always rerun kinship regardless of whether the algo was done already or not~~
- ~~Fixed identifiers to be truly unique in mapping steps when collecting run statistiscs~~
- Strelka output is wiped before running to make sure multiple runs do not share single output directory :white_check_mark:

