### PR TITLE
Put modules into their own namespace.

### DIFF
--- a/UMCU/Illumina/annotateVariants.pm
+++ b/UMCU/Illumina/annotateVariants.pm
@@ -10,12 +10,12 @@
 ### Authors: R.F.Ernst & H.H.D.Kerstens
 ##################################################################################################################################################
 
-package illumina_annotateVariants;
+package UMCU::Illumina::annotateVariants;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory                                                                                                              
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runAnnotateVariants {
     ###

--- a/UMCU/Illumina/baf.pm
+++ b/UMCU/Illumina/baf.pm
@@ -7,12 +7,12 @@
 ### Authors: R.F.Ernst 
 ##################################################################
 
-package illumina_baf;
+package UMCU::Illumina::baf;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runBAF {
     ###

--- a/UMCU/Illumina/baseRecal.pm
+++ b/UMCU/Illumina/baseRecal.pm
@@ -7,12 +7,12 @@
 ### Author: R.F.Ernst
 ####################################
 
-package illumina_baseRecal;
+package UMCU::Illumina::baseRecal;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runBaseRecalibration {
     ###

--- a/UMCU/Illumina/callableLoci.pm
+++ b/UMCU/Illumina/callableLoci.pm
@@ -7,12 +7,12 @@
 ### Authors: R.F.Ernst 
 ##################################################################
 
-package illumina_callableLoci;
+package UMCU::Illumina::callableLoci;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runCallableLoci {
     ###

--- a/UMCU/Illumina/calling.pm
+++ b/UMCU/Illumina/calling.pm
@@ -10,12 +10,12 @@
 ### Authors: R.F.Ernst & H.H.D.Kerstens
 ##################################################################
 
-package illumina_calling;
+package UMCU::Illumina::calling;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runVariantCalling {
     ###

--- a/UMCU/Illumina/check.pm
+++ b/UMCU/Illumina/check.pm
@@ -7,13 +7,13 @@
 ### Author: R.F.Ernst
 ########################################################################
 
-package illumina_check;
+package UMCU::Illumina::check;
 
 use strict;
 use POSIX qw(tmpnam);
 use FindBin;
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runCheck {
     ### 

--- a/UMCU/Illumina/copyNumber.pm
+++ b/UMCU/Illumina/copyNumber.pm
@@ -9,13 +9,13 @@
 ### Author: R.F.Ernst & H.H.D.Kerstens
 ##################################################################################################################################################
 
-package illumina_copyNumber;
+package UMCU::Illumina::copyNumber;
 
 use strict;
 use POSIX qw(tmpnam);
 use File::Path qw(make_path);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runCopyNumberTools {
     ### 

--- a/UMCU/Illumina/filterVariants.pm
+++ b/UMCU/Illumina/filterVariants.pm
@@ -8,12 +8,12 @@
 ### Authors: R.F.Ernst & H.H.D.Kerstens
 #############################################################
 
-package illumina_filterVariants;
+package UMCU::Illumina::filterVariants;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory                                                                                                              
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runFilterVariants {
     ###

--- a/UMCU/Illumina/mapping.pm
+++ b/UMCU/Illumina/mapping.pm
@@ -10,12 +10,12 @@
 ###
 ##################################################################################################################################################
 
-package illumina_mapping;
+package UMCU::Illumina::mapping;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runMapping {
     ###

--- a/UMCU/Illumina/nipt.pm
+++ b/UMCU/Illumina/nipt.pm
@@ -8,13 +8,13 @@
 ###
 #######################################################
 
-package illumina_nipt;
+package UMCU::Illumina::nipt;
 
 use strict;
 use POSIX qw(tmpnam);
 use FindBin;
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 
 sub runNipt {

--- a/UMCU/Illumina/poststats.pm
+++ b/UMCU/Illumina/poststats.pm
@@ -8,12 +8,12 @@
 ###
 #######################################################
 
-package illumina_poststats;
+package UMCU::Illumina::poststats;
 
 use strict;
 use POSIX qw(tmpnam);
 use FindBin;
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 
 sub runPostStats {

--- a/UMCU/Illumina/prestats.pm
+++ b/UMCU/Illumina/prestats.pm
@@ -7,12 +7,12 @@
 ### Author: S.W.Boymans & H.H.D.Kerstens
 ###################################
 
-package illumina_prestats;
+package UMCU::Illumina::prestats;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runPreStats {
     ###

--- a/UMCU/Illumina/realign.pm
+++ b/UMCU/Illumina/realign.pm
@@ -8,12 +8,12 @@
 ####
 ###################################################
 
-package illumina_realign;
+package UMCU::Illumina::realign;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runRealignment {
     ###

--- a/UMCU/Illumina/sge.pm
+++ b/UMCU/Illumina/sge.pm
@@ -4,7 +4,7 @@
 #
 
 
-package illumina_sge;
+package UMCU::Illumina::sge;
 use strict;
 use warnings;
 

--- a/UMCU/Illumina/somaticVariants.pm
+++ b/UMCU/Illumina/somaticVariants.pm
@@ -9,13 +9,13 @@
 ### Author: R.F.Ernst & H.H.D.Kerstens
 #########################################################
 
-package illumina_somaticVariants;
+package UMCU::Illumina::somaticVariants;
 
 use strict;
 use POSIX qw(tmpnam);
 use File::Path qw(make_path);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 ### Run and merge
 sub runSomaticVariantCallers {

--- a/UMCU/Illumina/structuralVariants.pm
+++ b/UMCU/Illumina/structuralVariants.pm
@@ -7,13 +7,13 @@
 ### Author: R.F.Ernst , M. van Roosmalen ,H.H.D.Kerstens
 ##################################################################
 
-package illumina_structuralVariants;
+package UMCU::Illumina::structuralVariants;
 
 use strict;
 use POSIX qw(tmpnam);
 use File::Path qw(make_path);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 sub runStructuralVariantCallers {
     ###

--- a/UMCU/Illumina/vcfutils.pm
+++ b/UMCU/Illumina/vcfutils.pm
@@ -10,12 +10,12 @@
 ###
 ############################################################
 
-package illumina_vcfutils;
+package UMCU::Illumina::vcfutils;
 
 use strict;
 use POSIX qw(tmpnam);
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_sge;
+use UMCU::Illumina::sge;
 
 
 sub runVcfUtils {

--- a/illumina_pipeline.pl
+++ b/illumina_pipeline.pl
@@ -20,22 +20,22 @@ use File::Basename qw( dirname );
 
 ### Load pipeline modules ####
 use lib "$FindBin::Bin"; #locates pipeline directory
-use illumina_prestats;
-use illumina_mapping;
-use illumina_poststats;
-use illumina_realign;
-use illumina_baseRecal;
-use illumina_calling;
-use illumina_filterVariants;
-use illumina_somaticVariants;
-use illumina_copyNumber;
-use illumina_structuralVariants;
-use illumina_baf;
-use illumina_callableLoci;
-use illumina_annotateVariants;
-use illumina_vcfutils;
-use illumina_nipt;
-use illumina_check;
+use UMCU::Illumina::prestats;
+use UMCU::Illumina::mapping;
+use UMCU::Illumina::poststats;
+use UMCU::Illumina::realign;
+use UMCU::Illumina::baseRecal;
+use UMCU::Illumina::calling;
+use UMCU::Illumina::filterVariants;
+use UMCU::Illumina::somaticVariants;
+use UMCU::Illumina::copyNumber;
+use UMCU::Illumina::structuralVariants;
+use UMCU::Illumina::baf;
+use UMCU::Illumina::callableLoci;
+use UMCU::Illumina::annotateVariants;
+use UMCU::Illumina::vcfutils;
+use UMCU::Illumina::nipt;
+use UMCU::Illumina::check;
 
 ### Check correct usage
 die usage() if @ARGV == 0;


### PR DESCRIPTION
I would like to put the modules into a namespace so that we can install them separately from the `illumina_pipeline.pl` script.

This way we can install the modules to: `%PREFIX%/lib/perl5/site_perl/` and the pipeline script to `%PREFIX%/bin/illumina_pipeline.pl`.

Please note that I haven't tested the change other than trying to see whether it can find the modules by default by running `perl illumina_pipeline.pl` from the project's root.  This worked, so I think this change does not affect the run-time of the pipeline.

